### PR TITLE
Show hostname in panel title

### DIFF
--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -73,6 +73,7 @@ dependencies = [
  "common",
  "cursive",
  "futures",
+ "hostname",
  "lazy_static",
  "openssl",
  "reqwest",
@@ -1038,6 +1039,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1279,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -23,6 +23,7 @@ time-humanize = "0.1.3"
 cursive = { version = "0.20.0", features = [
     "termion-backend",
 ], default-features = false }
+hostname = "0.3.1"
 
 # Server
 time = { version = "0.3.17", features = ["serde-well-known"] }

--- a/app/src/renderer/mod.rs
+++ b/app/src/renderer/mod.rs
@@ -95,8 +95,8 @@ impl Renderer {
             let padded_view = name_widget.child(content_widget);
             linear_layout.add_child(padded_view);
         });
-
-        Panel::new(PaddedView::lrtb(0, 0, 1, 0, linear_layout)).title("wgdisplay.local")
+        let title = Renderer::get_title();
+        Panel::new(PaddedView::lrtb(0, 0, 1, 0, linear_layout)).title(title)
     }
 
     /// Calls the update function on all enabled widgets
@@ -129,5 +129,18 @@ impl Renderer {
             .max()
             .unwrap()
             + 2
+    }
+
+    /// Computes the title of the application panel
+    /// # Returns
+    /// The title of the application panel
+    fn get_title() -> String {
+        match hostname::get() {
+            Ok(hostname) => match hostname.into_string() {
+                Ok(hostname) => format!("{}.local", hostname),
+                Err(_) => "hostname format error".into(),
+            },
+            Err(_) => "unkown hostname".into(),
+        }
     }
 }


### PR DESCRIPTION
Show hostname in panel title, so the user always knows what address leads to the configuration frontend